### PR TITLE
Add arbitrum and optimism testnets to dev

### DIFF
--- a/development.json
+++ b/development.json
@@ -1,30 +1,349 @@
 {
-  "version": 0,
-  "environment": "development",
-  "networks": [
-    "optimismkovan",
-    "rinkeby",
-    "neontestnet",
-    "arbitrumrinkeby",
-    "kovan",
-    "optimismkovan",
-    "rinkeby",
-    "neontestnet",
-    "arbitrumrinkeby",
-    "kovan",
-    "goerli",
-    "evmostestnet"
-  ],
-  "rpcs": {
-    "rinkeby": ["https://rinkeby-light.eth.linkpool.io"],
-    "evmostestnet": ["https://eth.bd.evmos.dev:8545"],
-    "arbitrumrinkeby": ["https://rinkeby.arbitrum.io/rpc"],
-    "neontestnet": ["https://proxy.devnet.neonlabs.org/solana"],
-    "goerli": ["https://goerli-light.eth.linkpool.io"],
-    "kovan": ["https://kovan.poa.network"],
-    "optimismkovan": ["https://kovan.optimism.io"]
+  "agent": {
+    "arbitrumrinkeby": {
+      "db": "/usr/share/nomad",
+      "kathy": {
+        "chat": {
+          "type": "default"
+        },
+        "enabled": true,
+        "interval": 500
+      },
+      "logging": {
+        "fmt": "json",
+        "level": "info"
+      },
+      "metrics": 9090,
+      "processor": {
+        "allowed": null,
+        "denied": null,
+        "enabled": true,
+        "interval": 5,
+        "s3": {
+          "bucket": "nomadxyz-development-proofs",
+          "region": "us-west-2"
+        },
+        "subsidizedRemotes": [
+          "kovan",
+          "goerli",
+          "evmostestnet",
+          "neontestnet",
+          "rinkeby",
+          "optimismkovan"
+        ]
+      },
+      "relayer": {
+        "enabled": true,
+        "interval": 10
+      },
+      "rpcStyle": "ethereum",
+      "updater": {
+        "enabled": true,
+        "interval": 5
+      },
+      "watcher": {
+        "enabled": true,
+        "interval": 5
+      }
+    },
+    "evmostestnet": {
+      "db": "/usr/share/nomad",
+      "kathy": {
+        "chat": {
+          "type": "default"
+        },
+        "enabled": true,
+        "interval": 500
+      },
+      "logging": {
+        "fmt": "json",
+        "level": "info"
+      },
+      "metrics": 9090,
+      "processor": {
+        "allowed": null,
+        "denied": null,
+        "enabled": true,
+        "interval": 5,
+        "s3": {
+          "bucket": "nomadxyz-development-proofs",
+          "region": "us-west-2"
+        },
+        "subsidizedRemotes": [
+          "rinkeby",
+          "kovan",
+          "goerli",
+          "neontestnet",
+          "arbitrumrinkeby",
+          "optimismkovan"
+        ]
+      },
+      "relayer": {
+        "enabled": true,
+        "interval": 10
+      },
+      "rpcStyle": "ethereum",
+      "updater": {
+        "enabled": true,
+        "interval": 5
+      },
+      "watcher": {
+        "enabled": true,
+        "interval": 5
+      }
+    },
+    "goerli": {
+      "db": "/usr/share/nomad",
+      "kathy": {
+        "chat": {
+          "type": "default"
+        },
+        "enabled": true,
+        "interval": 500
+      },
+      "logging": {
+        "fmt": "json",
+        "level": "info"
+      },
+      "metrics": 9090,
+      "processor": {
+        "allowed": null,
+        "denied": null,
+        "enabled": true,
+        "interval": 5,
+        "s3": {
+          "bucket": "nomadxyz-development-proofs",
+          "region": "us-west-2"
+        },
+        "subsidizedRemotes": [
+          "rinkeby",
+          "kovan",
+          "evmostestnet",
+          "neontestnet",
+          "arbitrumrinkeby",
+          "optimismkovan"
+        ]
+      },
+      "relayer": {
+        "enabled": true,
+        "interval": 10
+      },
+      "rpcStyle": "ethereum",
+      "updater": {
+        "enabled": true,
+        "interval": 5
+      },
+      "watcher": {
+        "enabled": true,
+        "interval": 5
+      }
+    },
+    "kovan": {
+      "db": "/usr/share/nomad",
+      "kathy": {
+        "chat": {
+          "type": "default"
+        },
+        "enabled": true,
+        "interval": 500
+      },
+      "logging": {
+        "fmt": "json",
+        "level": "info"
+      },
+      "metrics": 9090,
+      "processor": {
+        "allowed": null,
+        "denied": null,
+        "enabled": true,
+        "interval": 5,
+        "s3": {
+          "bucket": "nomadxyz-development-proofs",
+          "region": "us-west-2"
+        },
+        "subsidizedRemotes": [
+          "rinkeby",
+          "goerli",
+          "evmostestnet",
+          "neontestnet",
+          "arbitrumrinkeby",
+          "optimismkovan"
+        ]
+      },
+      "relayer": {
+        "enabled": true,
+        "interval": 10
+      },
+      "rpcStyle": "ethereum",
+      "updater": {
+        "enabled": true,
+        "interval": 5
+      },
+      "watcher": {
+        "enabled": true,
+        "interval": 5
+      }
+    },
+    "neontestnet": {
+      "db": "/usr/share/nomad",
+      "kathy": {
+        "chat": {
+          "type": "default"
+        },
+        "enabled": true,
+        "interval": 500
+      },
+      "logging": {
+        "fmt": "json",
+        "level": "info"
+      },
+      "metrics": 9090,
+      "processor": {
+        "allowed": null,
+        "denied": null,
+        "enabled": true,
+        "interval": 5,
+        "s3": {
+          "bucket": "nomadxyz-development-proofs",
+          "region": "us-west-2"
+        },
+        "subsidizedRemotes": [
+          "rinkeby",
+          "goerli",
+          "evmostestnet",
+          "kovan",
+          "arbitrumrinkeby",
+          "optimismkovan"
+        ]
+      },
+      "relayer": {
+        "enabled": true,
+        "interval": 10
+      },
+      "rpcStyle": "ethereum",
+      "updater": {
+        "enabled": true,
+        "interval": 5
+      },
+      "watcher": {
+        "enabled": true,
+        "interval": 5
+      }
+    },
+    "optimismkovan": {
+      "db": "/usr/share/nomad",
+      "kathy": {
+        "chat": {
+          "type": "default"
+        },
+        "enabled": true,
+        "interval": 500
+      },
+      "logging": {
+        "fmt": "json",
+        "level": "info"
+      },
+      "metrics": 9090,
+      "processor": {
+        "allowed": null,
+        "denied": null,
+        "enabled": true,
+        "interval": 5,
+        "s3": {
+          "bucket": "nomadxyz-development-proofs",
+          "region": "us-west-2"
+        },
+        "subsidizedRemotes": [
+          "kovan",
+          "goerli",
+          "evmostestnet",
+          "neontestnet",
+          "arbitrumrinkeby",
+          "rinkeby"
+        ]
+      },
+      "relayer": {
+        "enabled": true,
+        "interval": 10
+      },
+      "rpcStyle": "ethereum",
+      "updater": {
+        "enabled": true,
+        "interval": 5
+      },
+      "watcher": {
+        "enabled": true,
+        "interval": 5
+      }
+    },
+    "rinkeby": {
+      "db": "/usr/share/nomad",
+      "kathy": {
+        "chat": {
+          "type": "default"
+        },
+        "enabled": true,
+        "interval": 500
+      },
+      "logging": {
+        "fmt": "json",
+        "level": "info"
+      },
+      "metrics": 9090,
+      "processor": {
+        "allowed": null,
+        "denied": null,
+        "enabled": true,
+        "interval": 5,
+        "s3": {
+          "bucket": "nomadxyz-development-proofs",
+          "region": "us-west-2"
+        },
+        "subsidizedRemotes": [
+          "kovan",
+          "goerli",
+          "evmostestnet",
+          "neontestnet",
+          "arbitrumrinkeby",
+          "optimismkovan"
+        ]
+      },
+      "relayer": {
+        "enabled": true,
+        "interval": 10
+      },
+      "rpcStyle": "ethereum",
+      "updater": {
+        "enabled": true,
+        "interval": 5
+      },
+      "watcher": {
+        "enabled": true,
+        "interval": 5
+      }
+    }
   },
   "bridge": {
+    "arbitrumrinkeby": {
+      "bridgeRouter": {
+        "beacon": "0x4272e577e40b3146d0269d1276542bba2adeaabf",
+        "implementation": "0x5aaa45f1329af4d2dd46e6e6cd70924b87f2d7dd",
+        "proxy": "0x2288254096c0b5747c6f48a93fd17a03f83dda24"
+      },
+      "bridgeToken": {
+        "beacon": "0x3daa2126a75a205c25b540d791806b3445313ec0",
+        "implementation": "0xd926b924de53cf5adee4738f1608f7e25982499a",
+        "proxy": "0x0000000000000000000000000000000000000000"
+      },
+      "customs": [],
+      "deployHeight": 12099132,
+      "ethHelper": "0x54b74b0e24bf83fbd5081a99a99566048d231bfa",
+      "tokenRegistry": {
+        "beacon": "0x88b6740d1a8b3f25df6179fbcf83026867ee8523",
+        "implementation": "0x9301dcce67e663dda07be9a5166a8b2bde12bac3",
+        "proxy": "0xcd817d1fed120aad28c64817a4a0277bd81aaa9d"
+      }
+    },
     "evmostestnet": {
       "bridgeRouter": {
         "beacon": "0x3a58831408c67bf1ec7b4de773552c87a169b37e",
@@ -105,6 +424,26 @@
         "proxy": "0xc5109e06622689368755ee501a8282e3b9202617"
       }
     },
+    "optimismkovan": {
+      "bridgeRouter": {
+        "beacon": "0xc966ab655df40988f6ada362dbbfd4447dc47725",
+        "implementation": "0x1cad12645d171a46f64a2ac1695a5fd9c904ebfc",
+        "proxy": "0x9e76f5dfc22cfe83c06ef44fc318d5f923f33e2f"
+      },
+      "bridgeToken": {
+        "beacon": "0xbb9108c6fe2134be3445bbc6bfa57a223e66b612",
+        "implementation": "0x20fb023a95710adaa08ff87bd896cca4b15ec483",
+        "proxy": "0x0000000000000000000000000000000000000000"
+      },
+      "customs": [],
+      "deployHeight": 3474763,
+      "ethHelper": "0x5ed597d469a81534749e14a177e59d68278d6dbb",
+      "tokenRegistry": {
+        "beacon": "0x359b05839b46efb969d97cd76a2aa4e172c75bba",
+        "implementation": "0x5c61715188d0eedb81dcbdd0fba16fe5add751d9",
+        "proxy": "0x952abfc4283f8d93f38a2993330b1b60ca3a8249"
+      }
+    },
     "rinkeby": {
       "bridgeRouter": {
         "beacon": "0xa778962b0ffbe7bc4449c308513a196bfa344232",
@@ -171,6 +510,54 @@
     }
   },
   "core": {
+    "arbitrumrinkeby": {
+      "deployHeight": 12098988,
+      "governanceRouter": {
+        "beacon": "0x1631d12da55cbfb540d46e0dd9bbfb1d3f293dc8",
+        "implementation": "0x03aed5b64abb6012f3a0d79baa5cb91459be2db2",
+        "proxy": "0x6cc740e1e17b7b72e1d6c46afea4d44d86657102"
+      },
+      "home": {
+        "beacon": "0x4b162c5c62a67e8a1772c0f04715ed2606b51421",
+        "implementation": "0x0e41dbf2f9faa8f68eb854456ea855dae14accca",
+        "proxy": "0x884dad9316c61ed353b1d6931ba46663e1c3aacf"
+      },
+      "replicas": {
+        "evmostestnet": {
+          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7",
+          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
+          "proxy": "0xb372d6b312f678494cf4e1bf5d149e733640e968"
+        },
+        "goerli": {
+          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7",
+          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
+          "proxy": "0x5f4d75de162b4c050f27ce2f2374d50e3d7fbbb6"
+        },
+        "kovan": {
+          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7",
+          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
+          "proxy": "0xba7e081310d8bb7c6b6fa40e00389b8421133236"
+        },
+        "neontestnet": {
+          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7",
+          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
+          "proxy": "0x495ef7cfee3850ba2afb5fea4c7c06ee0d1d0d6e"
+        },
+        "optimismkovan": {
+          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7",
+          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
+          "proxy": "0xacaed04b586c0220eb6269e8769852a324355286"
+        },
+        "rinkeby": {
+          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7",
+          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
+          "proxy": "0x921dbedc12ba3299deaf8dd9fff0f435d8839edf"
+        }
+      },
+      "updaterManager": "0x7f1b402a570f3221e03e41ef2408b5a215bb0448",
+      "upgradeBeaconController": "0x87c44484add9020e7d6c98132311e1cd118ac236",
+      "xAppConnectionManager": "0x42e8c0f7981add4c8081be20c813d49571f446f4"
+    },
     "evmostestnet": {
       "deployHeight": 942883,
       "governanceRouter": {
@@ -184,6 +571,11 @@
         "proxy": "0x198740c6fc71308b2f97fe5d632ab46890bcb177"
       },
       "replicas": {
+        "arbitrumrinkeby": {
+          "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7",
+          "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
+          "proxy": "0x0ded84b55b52a68bfc808f5696e7b5ba2d8d335d"
+        },
         "goerli": {
           "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7",
           "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
@@ -198,6 +590,11 @@
           "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7",
           "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
           "proxy": "0x41737ac8a129f20707d914ff088a7ec3e57bc99b"
+        },
+        "optimismkovan": {
+          "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7",
+          "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
+          "proxy": "0x0ec74984011b13a96e09267b4395ac28e5f13f4d"
         },
         "rinkeby": {
           "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7",
@@ -222,6 +619,11 @@
         "proxy": "0x454f1ec431470063a1792ead14c1f10876796e5f"
       },
       "replicas": {
+        "arbitrumrinkeby": {
+          "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2",
+          "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
+          "proxy": "0x0ded84b55b52a68bfc808f5696e7b5ba2d8d335d"
+        },
         "evmostestnet": {
           "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2",
           "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
@@ -236,6 +638,11 @@
           "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2",
           "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
           "proxy": "0xe9239d33c26bef40ae87a2e211848fc8e7c7baa0"
+        },
+        "optimismkovan": {
+          "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2",
+          "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
+          "proxy": "0x0ec74984011b13a96e09267b4395ac28e5f13f4d"
         },
         "rinkeby": {
           "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2",
@@ -260,6 +667,11 @@
         "proxy": "0x4730144aa70a22bd04338e4589ec8f55618e73bf"
       },
       "replicas": {
+        "arbitrumrinkeby": {
+          "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d",
+          "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
+          "proxy": "0x0ded84b55b52a68bfc808f5696e7b5ba2d8d335d"
+        },
         "evmostestnet": {
           "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d",
           "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
@@ -274,6 +686,11 @@
           "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d",
           "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
           "proxy": "0xeb04adc8a451b9730ccf0b7f8ab1fb422c72c55a"
+        },
+        "optimismkovan": {
+          "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d",
+          "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
+          "proxy": "0xb7ff8c43c8dd80c6b2ab42525b056565627df677"
         },
         "rinkeby": {
           "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d",
@@ -298,6 +715,11 @@
         "proxy": "0x532814a2b5a5f4a30fd31d03ab32936d95a4e581"
       },
       "replicas": {
+        "arbitrumrinkeby": {
+          "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd",
+          "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
+          "proxy": "0x0ded84b55b52a68bfc808f5696e7b5ba2d8d335d"
+        },
         "evmostestnet": {
           "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd",
           "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
@@ -313,6 +735,11 @@
           "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
           "proxy": "0x226fa9744ce3e1b398abca71d7a794ec0a13e23e"
         },
+        "optimismkovan": {
+          "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd",
+          "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
+          "proxy": "0x0ec74984011b13a96e09267b4395ac28e5f13f4d"
+        },
         "rinkeby": {
           "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd",
           "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
@@ -322,6 +749,54 @@
       "updaterManager": "0xeb79540da3f802e63e63f99eb13c7803109def40",
       "upgradeBeaconController": "0x0dab5407446bfebb16990c8f586a91ba7bb2c189",
       "xAppConnectionManager": "0x9cb5abe515ca91a3851aa246d614a639ad88b735"
+    },
+    "optimismkovan": {
+      "deployHeight": 3474253,
+      "governanceRouter": {
+        "beacon": "0x847a1cd98bf276911d4e0939953024d89965a5e3",
+        "implementation": "0x5c1db088cd74c0df41002b2c0bca062e03d85330",
+        "proxy": "0x605811d4c135ea90c77ecbcdbf58430ec0ff452d"
+      },
+      "home": {
+        "beacon": "0x212bb3042ff07ed543e6caf97563429174db9618",
+        "implementation": "0x5caf9c8e47aa3b03747daa18b3d94e681e5b2dcb",
+        "proxy": "0x8c43f05c4bcdd2bd381fa04be9b8752f4f2ec76e"
+      },
+      "replicas": {
+        "arbitrumrinkeby": {
+          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4",
+          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
+          "proxy": "0x3c9e9cff71d402371c18ced7f5d6724e80da1ff0"
+        },
+        "evmostestnet": {
+          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4",
+          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
+          "proxy": "0x766de0c81b1589fa03aa7de37666941d7653fafe"
+        },
+        "goerli": {
+          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4",
+          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
+          "proxy": "0x6b16503909d856b7d4bdc6ca4de9cab485b2a1e4"
+        },
+        "kovan": {
+          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4",
+          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
+          "proxy": "0x8557f3af8740e4fa366d4c5d0f9b7f8fd6370fc2"
+        },
+        "neontestnet": {
+          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4",
+          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
+          "proxy": "0xefe642c185d56554174098bf68752816511dbc5a"
+        },
+        "rinkeby": {
+          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4",
+          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
+          "proxy": "0x2dff665beef8a4e6c6833f5c032169974d9846e7"
+        }
+      },
+      "updaterManager": "0x5939432f9276ed57d5c142d81e0384a3d28e04fd",
+      "upgradeBeaconController": "0xdee940e22758684b1f69a38578909d1db1c54996",
+      "xAppConnectionManager": "0xfec8f43f3656a58882c45fbc757804e96f27759a"
     },
     "rinkeby": {
       "deployHeight": 10537248,
@@ -336,6 +811,11 @@
         "proxy": "0x0977fc99b94fd769ea4fbbfa14777434f773ced2"
       },
       "replicas": {
+        "arbitrumrinkeby": {
+          "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a",
+          "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
+          "proxy": "0x676b7fbb358db45c434fb477c16dfd92fa436152"
+        },
         "evmostestnet": {
           "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a",
           "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
@@ -355,6 +835,11 @@
           "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a",
           "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
           "proxy": "0x08f8fb0d580e0ee422bc477d6098e401226a715a"
+        },
+        "optimismkovan": {
+          "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a",
+          "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
+          "proxy": "0x6025dd438e53f4614306dae895b13287391d6ab2"
         }
       },
       "updaterManager": "0xd7191ef96218836fd73f58c7579e88062e162321",
@@ -370,11 +855,13 @@
     "rinkeby": "evmDefault"
   },
   "networks": [
-    "goerli",
-    "neontestnet",
+    "optimismkovan",
     "rinkeby",
-    "evmostestnet",
-    "kovan"
+    "neontestnet",
+    "arbitrumrinkeby",
+    "kovan",
+    "goerli",
+    "evmostestnet"
   ],
   "protocol": {
     "governor": {
@@ -382,109 +869,27 @@
       "id": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec"
     },
     "networks": {
-      "optimismkovan": {
-        "name": "optimismkovan",
-        "domain": 8881,
-        "connections": [
-          "kovan",
-          "neontestnet",
-          "arbitrumrinkeby",
-          "goerli",
-          "evmostestnet",
-          "rinkeby"
-        ],
+      "arbitrumrinkeby": {
+        "bridgeConfiguration": {
+          "customs": [],
+          "deployGas": 85000000,
+          "mintGas": 20000000,
+          "weth": "0xebbc3452cc911591e4f18f3b36727df45d6bd1f9"
+        },
         "configuration": {
-          "optimisticSeconds": 1800,
-          "processGas": 85000000,
-          "reserveGas": 2500000,
-          "maximumGas": 100000000,
-          "updater": "0xbd8f1387b91c3e91ea836d871e8e7a2c26c118e0",
-          "watchers": ["0x295d72cb3753d9e38a8fce5024cf8b9e280385f1"],
           "governance": {
             "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
             "recoveryTimelock": 86400
-          }
-        },
-        "connections": [
-          "neontestnet",
-          "kovan",
-          "rinkeby",
-          "goerli"
-        ],
-        "domain": 4001,
-        "name": "evmostestnet",
-        "specs": {
-          "chainId": 69,
-          "blockTime": 15,
-          "finalizationBlocks": 3,
-          "supports1559": false,
-          "confirmations": 1,
-          "blockExplorer": "https://kovan-optimistic.etherscan.io",
-          "indexPageSize": 2000
-        },
-        "bridgeConfiguration": {
-          "weth": "0xebbc3452cc911591e4f18f3b36727df45d6bd1f9",
-          "customs": [],
-          "mintGas": 20000000,
-          "deployGas": 85000000
-        }
-      },
-      "neontestnet": {
-        "name": "neontestnet",
-        "domain": 5001,
-        "connections": [
-          "evmostestnet",
-          "goerli",
-          "kovan",
-          "rinkeby",
-          "optimismkovan",
-          "arbitrumrinkeby"
-        ],
-        "configuration": {
+          },
+          "maximumGas": 100000000,
           "optimisticSeconds": 1800,
           "processGas": 85000000,
           "reserveGas": 2500000,
-          "maximumGas": 100000000,
-          "updater": "0xa4e6e0953443882f448b93de52abfe7eb8b2efd4",
-          "watchers": ["0xdc030a4e198dd6d08a7497b3deaf644ad755c10b"],
-          "governance": {
-            "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
-            "recoveryTimelock": 180
-          },
-          "maximumGas": 1000000,
-          "optimisticSeconds": 1800,
-          "processGas": 850000,
-          "reserveGas": 25000,
-          "updater": "0xa4e6e0953443882f448b93de52abfe7eb8b2efd4",
+          "updater": "0xbfcec115c9019c40855130714a2450f22728594a",
           "watchers": [
-            "0xdc030a4e198dd6d08a7497b3deaf644ad755c10b"
+            "0xe6252c87d801d8d9008d1b7b2886fb788675db29"
           ]
         },
-        "specs": {
-          "blockExplorer": "https://neonscan.org/",
-          "blockTime": 1,
-          "chainId": 245022934,
-          "confirmations": 10,
-          "blockTime": 1,
-          "finalizationBlocks": 32,
-          "indexPageSize": 2000,
-          "supports1559": false
-          "supports1559": false,
-          "confirmations": 10,
-          "blockExplorer": "https://neonscan.org/",
-          "indexPageSize": 2000
-        },
-        "bridgeConfiguration": {
-          "weth": "0xf8ad328e98f85fccbf09e43b16dcbbda7e84beab",
-          "customs": [],
-          "mintGas": 20000,
-          "deployGas": 85000000
-        }
-      },
-      "rinkeby": {
-      "arbitrumrinkeby": {
-        "name": "arbitrumrinkeby",
-        "domain": 6661,
         "connections": [
           "evmostestnet",
           "neontestnet",
@@ -493,41 +898,121 @@
           "goerli",
           "optimismkovan"
         ],
+        "domain": 6661,
+        "name": "arbitrumrinkeby",
+        "specs": {
+          "blockExplorer": "https://testnet.arbiscan.io/",
+          "blockTime": 15,
+          "chainId": 421611,
+          "confirmations": 1,
+          "finalizationBlocks": 3,
+          "indexPageSize": 2000,
+          "supports1559": false
+        }
+      },
+      "evmostestnet": {
+        "bridgeConfiguration": {
+          "customs": [],
+          "deployGas": 85000000,
+          "mintGas": 20000000,
+          "weth": "0xcc491f589b45d4a3c679016195b3fb87d7848210"
+        },
         "configuration": {
-          "optimisticSeconds": 1800,
-          "processGas": 85000000,
-          "reserveGas": 2500000,
-          "maximumGas": 100000000,
-          "updater": "0xbfcec115c9019c40855130714a2450f22728594a",
-          "watchers": ["0xe6252c87d801d8d9008d1b7b2886fb788675db29"],
           "governance": {
             "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
-            "recoveryTimelock": 86400
-          }
+            "recoveryTimelock": 180
+          },
+          "maximumGas": 100000000,
+          "optimisticSeconds": 10,
+          "processGas": 85000000,
+          "reserveGas": 1500000,
+          "updater": "0x815d2281a9ebacfbffa4294375de6e14f2522d87",
+          "watchers": [
+            "0xafcf8db79e999cb79260572fb61c8e5006b855a4"
+          ]
         },
+        "connections": [
+          "optimismkovan",
+          "goerli",
+          "neontestnet",
+          "arbitrumrinkeby",
+          "kovan",
+          "rinkeby"
+        ],
+        "domain": 4001,
+        "name": "evmostestnet",
         "specs": {
-          "chainId": 421611,
-          "blockTime": 15,
-          "finalizationBlocks": 3,
-          "supports1559": false,
-          "confirmations": 1,
-          "blockExplorer": "https://testnet.arbiscan.io/",
-          "indexPageSize": 2000
-        },
+          "blockExplorer": "https://evm.evmos.dev/",
+          "blockTime": 5,
+          "chainId": 9000,
+          "confirmations": 6,
+          "finalizationBlocks": 10,
+          "indexPageSize": 2000,
+          "supports1559": false
+        }
+      },
+      "goerli": {
         "bridgeConfiguration": {
-          "weth": "0xebbc3452cc911591e4f18f3b36727df45d6bd1f9",
           "customs": [],
-          "deployGas": 850000,
-          "mintGas": 200000,
-          "weth": "0xc778417e063141139fce010982780140aa0cd5ab"
-        },
+          "deployGas": 85000000,
           "mintGas": 20000000,
-          "deployGas": 85000000
+          "weth": "0x0bb7509324ce409f7bbc4b701f932eaca9736ab7"
+        },
+        "configuration": {
+          "governance": {
+            "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
+            "recoveryTimelock": 180
+          },
+          "maximumGas": 100000000,
+          "optimisticSeconds": 10,
+          "processGas": 85000000,
+          "reserveGas": 1500000,
+          "updater": "0xd16bdbbc56090156ec609ebebc8bace1240fa22e",
+          "watchers": [
+            "0x69520f1cec6199fe93c6c77881b5de701e0efeff"
+          ]
+        },
+        "connections": [
+          "arbitrumrinkeby",
+          "kovan",
+          "optimismkovan",
+          "neontestnet",
+          "evmostestnet",
+          "rinkeby"
+        ],
+        "domain": 3001,
+        "name": "goerli",
+        "specs": {
+          "blockExplorer": "https://goerli.etherscan.io/",
+          "blockTime": 15,
+          "chainId": 5,
+          "confirmations": 4,
+          "finalizationBlocks": 30,
+          "indexPageSize": 2000,
+          "supports1559": true
         }
       },
       "kovan": {
-        "name": "kovan",
-        "domain": 2001,
+        "bridgeConfiguration": {
+          "customs": [],
+          "deployGas": 85000000,
+          "mintGas": 20000000,
+          "weth": "0xd0a1e359811322d97991e03f863a0c30c2cf029c"
+        },
+        "configuration": {
+          "governance": {
+            "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
+            "recoveryTimelock": 180
+          },
+          "maximumGas": 100000000,
+          "optimisticSeconds": 10,
+          "processGas": 85000000,
+          "reserveGas": 1500000,
+          "updater": "0x45818549c1e7d16c915fe23c1524b524507a184b",
+          "watchers": [
+            "0xe8c6bf61d5f5744f465865772e1de88059267bac"
+          ]
+        },
         "connections": [
           "arbitrumrinkeby",
           "rinkeby",
@@ -536,39 +1021,121 @@
           "evmostestnet",
           "neontestnet"
         ],
+        "domain": 2001,
+        "name": "kovan",
+        "specs": {
+          "blockExplorer": "https://kovan.etherscan.io/",
+          "blockTime": 4,
+          "chainId": 42,
+          "confirmations": 15,
+          "finalizationBlocks": 10,
+          "indexPageSize": 2000,
+          "supports1559": false
+        }
+      },
+      "neontestnet": {
+        "bridgeConfiguration": {
+          "customs": [],
+          "deployGas": 85000000,
+          "mintGas": 20000,
+          "weth": "0xf8ad328e98f85fccbf09e43b16dcbbda7e84beab"
+        },
         "configuration": {
-          "optimisticSeconds": 10,
-          "processGas": 85000000,
-          "reserveGas": 1500000,
-          "maximumGas": 100000000,
-          "updater": "0x45818549c1e7d16c915fe23c1524b524507a184b",
-          "watchers": ["0xe8c6bf61d5f5744f465865772e1de88059267bac"],
           "governance": {
             "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
             "recoveryTimelock": 180
           },
-          "maximumGas": 1000000,
-          }
+          "maximumGas": 100000000,
+          "optimisticSeconds": 1800,
+          "processGas": 85000000,
+          "reserveGas": 2500000,
+          "updater": "0xa4e6e0953443882f448b93de52abfe7eb8b2efd4",
+          "watchers": [
+            "0xdc030a4e198dd6d08a7497b3deaf644ad755c10b"
+          ]
         },
+        "connections": [
+          "evmostestnet",
+          "goerli",
+          "kovan",
+          "rinkeby",
+          "optimismkovan",
+          "arbitrumrinkeby"
+        ],
+        "domain": 5001,
+        "name": "neontestnet",
         "specs": {
-          "chainId": 42,
-          "blockTime": 4,
-          "finalizationBlocks": 10,
-          "supports1559": false,
-          "confirmations": 15,
-          "blockExplorer": "https://kovan.etherscan.io/",
-          "indexPageSize": 2000
-        },
+          "blockExplorer": "https://neonscan.org/",
+          "blockTime": 1,
+          "chainId": 245022934,
+          "confirmations": 10,
+          "finalizationBlocks": 32,
+          "indexPageSize": 2000,
+          "supports1559": false
+        }
+      },
+      "optimismkovan": {
         "bridgeConfiguration": {
-          "weth": "0xd0a1e359811322d97991e03f863a0c30c2cf029c",
           "customs": [],
+          "deployGas": 85000000,
           "mintGas": 20000000,
-          "deployGas": 85000000
+          "weth": "0xebbc3452cc911591e4f18f3b36727df45d6bd1f9"
+        },
+        "configuration": {
+          "governance": {
+            "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
+            "recoveryTimelock": 86400
+          },
+          "maximumGas": 100000000,
+          "optimisticSeconds": 1800,
+          "processGas": 85000000,
+          "reserveGas": 2500000,
+          "updater": "0xbd8f1387b91c3e91ea836d871e8e7a2c26c118e0",
+          "watchers": [
+            "0x295d72cb3753d9e38a8fce5024cf8b9e280385f1"
+          ]
+        },
+        "connections": [
+          "kovan",
+          "neontestnet",
+          "arbitrumrinkeby",
+          "goerli",
+          "evmostestnet",
+          "rinkeby"
+        ],
+        "domain": 8881,
+        "name": "optimismkovan",
+        "specs": {
+          "blockExplorer": "https://kovan-optimistic.etherscan.io",
+          "blockTime": 15,
+          "chainId": 69,
+          "confirmations": 1,
+          "finalizationBlocks": 3,
+          "indexPageSize": 2000,
+          "supports1559": false
         }
       },
       "rinkeby": {
-        "name": "rinkeby",
-        "domain": 1001,
+        "bridgeConfiguration": {
+          "customs": [],
+          "deployGas": 85000000,
+          "mintGas": 20000000,
+          "weth": "0xc778417e063141139fce010982780140aa0cd5ab"
+        },
+        "configuration": {
+          "governance": {
+            "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
+            "recoveryTimelock": 180
+          },
+          "maximumGas": 100000000,
+          "optimisticSeconds": 10,
+          "processGas": 85000000,
+          "reserveGas": 1500000,
+          "updater": "0xe80d5d65275208aee8e10609258e4e048eb86b4c",
+          "watchers": [
+            "0x8ad65ba028cae9e3932959d5c167a09ede941d2c"
+          ]
+        },
         "connections": [
           "neontestnet",
           "evmostestnet",
@@ -577,129 +1144,24 @@
           "goerli",
           "optimismkovan"
         ],
-        "configuration": {
-          "optimisticSeconds": 10,
-          "processGas": 850000,
-          "reserveGas": 15000,
-          "processGas": 85000000,
-          "reserveGas": 1500000,
-          "maximumGas": 100000000,
-          "updater": "0xe80d5d65275208aee8e10609258e4e048eb86b4c",
-          "watchers": [
-            "0x8ad65ba028cae9e3932959d5c167a09ede941d2c"
-          ]
-          "watchers": ["0x8ad65ba028cae9e3932959d5c167a09ede941d2c"],
-          "governance": {
-            "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
-            "recoveryTimelock": 180
-          }
-        },
-        "specs": {
-          "chainId": 4,
-          "blockTime": 15,
-          "finalizationBlocks": 30,
-          "supports1559": true,
-          "confirmations": 4,
-          "blockExplorer": "https://rinkeby.etherscan.io/",
-          "indexPageSize": 2000
-        },
-        "bridgeConfiguration": {
-          "weth": "0xc778417e063141139fce010982780140aa0cd5ab",
-          "customs": [],
-          "mintGas": 20000000,
-          "deployGas": 85000000
-        }
-      },
-      "evmostestnet": {
-        "name": "evmostestnet",
-        "domain": 4001,
-        "connections": [
-          "optimismkovan",
-          "goerli",
-          "neontestnet",
-          "arbitrumrinkeby",
-          "kovan",
-          "rinkeby"
-        ],
-        "configuration": {
-          "optimisticSeconds": 10,
-          "processGas": 85000000,
-          "reserveGas": 1500000,
-          "maximumGas": 100000000,
-          "updater": "0x815d2281a9ebacfbffa4294375de6e14f2522d87",
-          "watchers": ["0xafcf8db79e999cb79260572fb61c8e5006b855a4"],
-          "governance": {
-            "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
-            "recoveryTimelock": 180
-          }
-        },
-        "specs": {
-          "chainId": 9000,
-          "blockTime": 5,
-          "finalizationBlocks": 10,
-          "supports1559": false,
-          "confirmations": 6,
-          "blockExplorer": "https://evm.evmos.dev/",
-          "indexPageSize": 2000
-        },
-        "bridgeConfiguration": {
-          "weth": "0xcc491f589b45d4a3c679016195b3fb87d7848210",
-          "customs": [],
-          "mintGas": 20000000,
-          "deployGas": 85000000
-        }
-      },
-      "goerli": {
-        "name": "goerli",
-        "domain": 3001,
-        "connections": [
-          "arbitrumrinkeby",
-          "kovan",
-          "evmostestnet",
-          "optimismkovan",
-          "neontestnet",
-          "goerli"
-          "evmostestnet",
-          "rinkeby"
-        ],
         "domain": 1001,
         "name": "rinkeby",
-        "configuration": {
-          "optimisticSeconds": 10,
-          "processGas": 85000000,
-          "reserveGas": 1500000,
-          "maximumGas": 100000000,
-          "updater": "0xd16bdbbc56090156ec609ebebc8bace1240fa22e",
-          "watchers": ["0x69520f1cec6199fe93c6c77881b5de701e0efeff"],
-          "governance": {
-            "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
-            "recoveryTimelock": 180
-          }
-        },
         "specs": {
           "blockExplorer": "https://rinkeby.etherscan.io/",
-          "chainId": 5,
           "blockTime": 15,
           "chainId": 4,
-          "finalizationBlocks": 30,
-          "supports1559": true,
           "confirmations": 4,
-          "finalizationBlocks": 80,
+          "finalizationBlocks": 30,
           "indexPageSize": 2000,
           "supports1559": true
-          "blockExplorer": "https://goerli.etherscan.io/",
-          "indexPageSize": 2000
-        },
-        "bridgeConfiguration": {
-          "weth": "0x0bb7509324ce409f7bbc4b701f932eaca9736ab7",
-          "customs": [],
-          "mintGas": 20000000,
-          "deployGas": 85000000
         }
       }
     }
   },
   "rpcs": {
+    "arbitrumrinkeby": [
+      "https://rinkeby.arbitrum.io/rpc"
+    ],
     "evmostestnet": [
       "https://eth.bd.evmos.dev:8545"
     ],
@@ -712,868 +1174,12 @@
     "neontestnet": [
       "https://proxy.devnet.neonlabs.org/solana"
     ],
+    "optimismkovan": [
+      "https://kovan.optimism.io"
+    ],
     "rinkeby": [
       "https://rinkeby-light.eth.linkpool.io"
     ]
   },
   "version": 0
-  "core": {
-    "evmostestnet": {
-      "deployHeight": 942883,
-      "upgradeBeaconController": "0xbe288f49557a2e70bc54840c5a96e84747aa9431",
-      "xAppConnectionManager": "0x224f3558770ad0740ed94bbdea79e197e51852bd",
-      "updaterManager": "0x9095f216b9cb3f1da981062ec81114a2c7494cd4",
-      "governanceRouter": {
-        "implementation": "0x56c4c4eb8901fd25a37224cef34c92301f182f47",
-        "proxy": "0x505d0ffb3cb00738338045b88d9a995e2f427017",
-        "beacon": "0x6d7c1abe3dc804a69d7c96ba34edea3a8b9c4826"
-      },
-      "home": {
-        "implementation": "0x326cb118da8d26f04758db280705094292eac18c",
-        "proxy": "0x198740c6fc71308b2f97fe5d632ab46890bcb177",
-        "beacon": "0x3fbcb5d882d706c9dea852700c7c35d1087d8740"
-      },
-      "replicas": {
-        "goerli": {
-          "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
-          "proxy": "0xff1000469744aa20630ae61d5f9f461b08755582",
-          "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7"
-        },
-        "neontestnet": {
-          "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
-          "proxy": "0x41737ac8a129f20707d914ff088a7ec3e57bc99b",
-          "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7"
-        },
-        "kovan": {
-          "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
-          "proxy": "0x745f85d60c6afe77a6465336b87f4baaa5418a13",
-          "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7"
-        },
-        "rinkeby": {
-          "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
-          "proxy": "0x362f6d97609501e630ad8a5da2f211675cac591e",
-          "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7"
-        },
-        "optimismkovan": {
-          "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
-          "proxy": "0x0ec74984011b13a96e09267b4395ac28e5f13f4d",
-          "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7"
-        },
-        "arbitrumrinkeby": {
-          "implementation": "0x67e9837aa16f425b379aaf7e4d5581e59d577cf2",
-          "proxy": "0x0ded84b55b52a68bfc808f5696e7b5ba2d8d335d",
-          "beacon": "0xa38bdbd738e81a93e006959f1ea6565bb033c8d7"
-        }
-      }
-    },
-    "neontestnet": {
-      "deployHeight": 131966188,
-      "upgradeBeaconController": "0x0dab5407446bfebb16990c8f586a91ba7bb2c189",
-      "xAppConnectionManager": "0x9cb5abe515ca91a3851aa246d614a639ad88b735",
-      "updaterManager": "0xeb79540da3f802e63e63f99eb13c7803109def40",
-      "governanceRouter": {
-        "implementation": "0xe6034b2f02ffe38563c0f96252577ceedb00b4f5",
-        "proxy": "0x0e4024950d71f630d710f8523e4e40656a2cd617",
-        "beacon": "0xf2e2da66eaacc274469c29149d9ba5996fad5449"
-      },
-      "home": {
-        "implementation": "0x38789a24cf7bd4b1f3bf5cebb7498c2662de92d3",
-        "proxy": "0x532814a2b5a5f4a30fd31d03ab32936d95a4e581",
-        "beacon": "0x0ae0010822fccb4778d18c5dfecb53ac6074ddf4"
-      },
-      "replicas": {
-        "evmostestnet": {
-          "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
-          "proxy": "0x9eedb4e71296a17a52dba260906394bc559e35e2",
-          "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd"
-        },
-        "arbitrumrinkeby": {
-          "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
-          "proxy": "0x0ded84b55b52a68bfc808f5696e7b5ba2d8d335d",
-          "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd"
-        },
-        "goerli": {
-          "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
-          "proxy": "0x124a74f83f6dceef8b6e712f5977e2e0c924bfbf",
-          "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd"
-        },
-        "rinkeby": {
-          "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
-          "proxy": "0xd9d656c4c8de9e66422589724796e2514fa59b1c",
-          "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd"
-        },
-        "kovan": {
-          "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
-          "proxy": "0x226fa9744ce3e1b398abca71d7a794ec0a13e23e",
-          "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd"
-        },
-        "optimismkovan": {
-          "implementation": "0xd14eebfb2c1267f88dd0b362c86e41517680dbc3",
-          "proxy": "0x0ec74984011b13a96e09267b4395ac28e5f13f4d",
-          "beacon": "0xb02a38bdf558321ac00f823d2593e216bee873dd"
-        }
-      }
-    },
-    "arbitrumrinkeby": {
-      "deployHeight": 12098988,
-      "upgradeBeaconController": "0x87c44484add9020e7d6c98132311e1cd118ac236",
-      "xAppConnectionManager": "0x42e8c0f7981add4c8081be20c813d49571f446f4",
-      "updaterManager": "0x7f1b402a570f3221e03e41ef2408b5a215bb0448",
-      "governanceRouter": {
-        "implementation": "0x03aed5b64abb6012f3a0d79baa5cb91459be2db2",
-        "proxy": "0x6cc740e1e17b7b72e1d6c46afea4d44d86657102",
-        "beacon": "0x1631d12da55cbfb540d46e0dd9bbfb1d3f293dc8"
-      },
-      "home": {
-        "implementation": "0x0e41dbf2f9faa8f68eb854456ea855dae14accca",
-        "proxy": "0x884dad9316c61ed353b1d6931ba46663e1c3aacf",
-        "beacon": "0x4b162c5c62a67e8a1772c0f04715ed2606b51421"
-      },
-      "replicas": {
-        "neontestnet": {
-          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
-          "proxy": "0x495ef7cfee3850ba2afb5fea4c7c06ee0d1d0d6e",
-          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7"
-        },
-        "goerli": {
-          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
-          "proxy": "0x5f4d75de162b4c050f27ce2f2374d50e3d7fbbb6",
-          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7"
-        },
-        "kovan": {
-          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
-          "proxy": "0xba7e081310d8bb7c6b6fa40e00389b8421133236",
-          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7"
-        },
-        "evmostestnet": {
-          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
-          "proxy": "0xb372d6b312f678494cf4e1bf5d149e733640e968",
-          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7"
-        },
-        "optimismkovan": {
-          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
-          "proxy": "0xacaed04b586c0220eb6269e8769852a324355286",
-          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7"
-        },
-        "rinkeby": {
-          "implementation": "0xd336a4b868ef5652268ff9c7de86de95c678909a",
-          "proxy": "0x921dbedc12ba3299deaf8dd9fff0f435d8839edf",
-          "beacon": "0x0c09e151720e0bcf4e2db42a3b5608b3de78e8d7"
-        }
-      }
-    },
-    "optimismkovan": {
-      "deployHeight": 3474253,
-      "upgradeBeaconController": "0xdee940e22758684b1f69a38578909d1db1c54996",
-      "xAppConnectionManager": "0xfec8f43f3656a58882c45fbc757804e96f27759a",
-      "updaterManager": "0x5939432f9276ed57d5c142d81e0384a3d28e04fd",
-      "governanceRouter": {
-        "implementation": "0x5c1db088cd74c0df41002b2c0bca062e03d85330",
-        "proxy": "0x605811d4c135ea90c77ecbcdbf58430ec0ff452d",
-        "beacon": "0x847a1cd98bf276911d4e0939953024d89965a5e3"
-      },
-      "home": {
-        "implementation": "0x5caf9c8e47aa3b03747daa18b3d94e681e5b2dcb",
-        "proxy": "0x8c43f05c4bcdd2bd381fa04be9b8752f4f2ec76e",
-        "beacon": "0x212bb3042ff07ed543e6caf97563429174db9618"
-      },
-      "replicas": {
-        "arbitrumrinkeby": {
-          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
-          "proxy": "0x3c9e9cff71d402371c18ced7f5d6724e80da1ff0",
-          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4"
-        },
-        "neontestnet": {
-          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
-          "proxy": "0xefe642c185d56554174098bf68752816511dbc5a",
-          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4"
-        },
-        "rinkeby": {
-          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
-          "proxy": "0x2dff665beef8a4e6c6833f5c032169974d9846e7",
-          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4"
-        },
-        "kovan": {
-          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
-          "proxy": "0x8557f3af8740e4fa366d4c5d0f9b7f8fd6370fc2",
-          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4"
-        },
-        "goerli": {
-          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
-          "proxy": "0x6b16503909d856b7d4bdc6ca4de9cab485b2a1e4",
-          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4"
-        },
-        "evmostestnet": {
-          "implementation": "0x8c2f5ddba5c1e66445a53ce8a9b13c21f29923ea",
-          "proxy": "0x766de0c81b1589fa03aa7de37666941d7653fafe",
-          "beacon": "0x0c4baf5c6e21da386dfe82fdd57fb6a8d6aca7b4"
-        }
-      }
-    },
-    "goerli": {
-      "deployHeight": 6748555,
-      "upgradeBeaconController": "0x5bba73ef76bf303c0b48ade5d611bb2f80471653",
-      "xAppConnectionManager": "0x859943879f79ce8d2e9e1d8c848c7ce9f6eb63d8",
-      "updaterManager": "0x75bd8ab02238dca52f303013f038d4e2d834e8fc",
-      "governanceRouter": {
-        "implementation": "0x79ea0091b38cb6a95bef2ae3bdbf28af49ba1c28",
-        "proxy": "0x66d093d20b3dd088397695c65df980c014da5e3e",
-        "beacon": "0xaabd0850ab63a1e856521b900b40b496a99e8560"
-      },
-      "home": {
-        "implementation": "0x0ef8ad9603f15127916e2d4777453ac885ae4669",
-        "proxy": "0x454f1ec431470063a1792ead14c1f10876796e5f",
-        "beacon": "0x25ec670059754b859fdcbdb6802c7644fd0a1af5"
-      },
-      "replicas": {
-        "evmostestnet": {
-          "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
-          "proxy": "0xf1b83d100860887aef35e50b3794e28dc744e5ce",
-          "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2"
-        },
-        "kovan": {
-          "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
-          "proxy": "0x9df21c4a016b8bd84000b29a3ba51980ddd7b37a",
-          "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2"
-        },
-        "rinkeby": {
-          "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
-          "proxy": "0xf405c58d95a8f2617505841bdacef6de27006d74",
-          "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2"
-        },
-        "neontestnet": {
-          "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
-          "proxy": "0xe9239d33c26bef40ae87a2e211848fc8e7c7baa0",
-          "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2"
-        },
-        "optimismkovan": {
-          "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
-          "proxy": "0x0ec74984011b13a96e09267b4395ac28e5f13f4d",
-          "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2"
-        },
-        "arbitrumrinkeby": {
-          "implementation": "0x8a36fbccc8d844aaacbca71e7ec8847215bb82f2",
-          "proxy": "0x0ded84b55b52a68bfc808f5696e7b5ba2d8d335d",
-          "beacon": "0x4a455cbabd96dc9b0dba2f0ccbb58a2dad403df2"
-        }
-      }
-    },
-    "kovan": {
-      "deployHeight": 31134284,
-      "upgradeBeaconController": "0xb0aefe5a88eeda7af7171c57430b153251275c33",
-      "xAppConnectionManager": "0x5240cc5f271f6dcbcc5ec67be04fd9de0f50f91f",
-      "updaterManager": "0x8bd3e4b2ef10491fcc9153840a8ca54c7e7738bf",
-      "governanceRouter": {
-        "implementation": "0xf4a442eeecc3e275d5ed4d91ec6231c7ab8e2386",
-        "proxy": "0x3f7754a3e178acc32ff8d5887b38f4e7b1673d8b",
-        "beacon": "0xd3bd51f18b7a77f2d16364ec0e7a8e499f86c8e9"
-      },
-      "home": {
-        "implementation": "0x397a0edbdd4c89d1dad557ae5bac75f585d77b7d",
-        "proxy": "0x4730144aa70a22bd04338e4589ec8f55618e73bf",
-        "beacon": "0x1c29678a918b8b4823a76b542b199b82cf4629ba"
-      },
-      "replicas": {
-        "rinkeby": {
-          "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
-          "proxy": "0x523c830c9007b595609a7e5f4885eeae6a4d2318",
-          "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d"
-        },
-        "goerli": {
-          "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
-          "proxy": "0x9969e1b2a9f81fc9066897b4865b58443967024b",
-          "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d"
-        },
-        "evmostestnet": {
-          "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
-          "proxy": "0x5dcbdfe40ef9e865b3cc2c90c517c557b2fa91c8",
-          "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d"
-        },
-        "arbitrumrinkeby": {
-          "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
-          "proxy": "0x0ded84b55b52a68bfc808f5696e7b5ba2d8d335d",
-          "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d"
-        },
-        "neontestnet": {
-          "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
-          "proxy": "0xeb04adc8a451b9730ccf0b7f8ab1fb422c72c55a",
-          "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d"
-        },
-        "optimismkovan": {
-          "implementation": "0x18f4019f6620e1593059b5a0518ceed6a6634373",
-          "proxy": "0xb7ff8c43c8dd80c6b2ab42525b056565627df677",
-          "beacon": "0x6c6b091665520088dbfe8ccb1ecb1d0556814e0d"
-        }
-      }
-    },
-    "rinkeby": {
-      "deployHeight": 10537248,
-      "upgradeBeaconController": "0xffc73f39f22ebfbe4643c7abcd972edc62bfb371",
-      "xAppConnectionManager": "0xb26806b76540348d655a12a5b8427ee088459625",
-      "updaterManager": "0xd7191ef96218836fd73f58c7579e88062e162321",
-      "governanceRouter": {
-        "implementation": "0xebedb3243a24a940f086de8cadc96883df56e9de",
-        "proxy": "0xfbb2fec4fcb5738c739b9705e723117581cbabeb",
-        "beacon": "0x0574d16015f9eef1d228c3c02d551ca8a7458036"
-      },
-      "home": {
-        "implementation": "0x87787132ad6282c156ed3e3aaeebbfbc35728f15",
-        "proxy": "0x0977fc99b94fd769ea4fbbfa14777434f773ced2",
-        "beacon": "0x8c49b91b307cd9d00838b947cf7f4a25bc051152"
-      },
-      "replicas": {
-        "neontestnet": {
-          "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
-          "proxy": "0x08f8fb0d580e0ee422bc477d6098e401226a715a",
-          "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a"
-        },
-        "kovan": {
-          "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
-          "proxy": "0x097a3eb6cd351ab28de67a0a0bda9e0e32733da7",
-          "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a"
-        },
-        "optimismkovan": {
-          "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
-          "proxy": "0x6025dd438e53f4614306dae895b13287391d6ab2",
-          "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a"
-        },
-        "evmostestnet": {
-          "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
-          "proxy": "0x423b1eced988959067834b13b501c8ab78a28576",
-          "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a"
-        },
-        "goerli": {
-          "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
-          "proxy": "0x96ee295d2c96ea0353b25ff0b8e8e0b8e64db60f",
-          "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a"
-        },
-        "arbitrumrinkeby": {
-          "implementation": "0xad74bef73458ddb8646af7a2e9a56734fa44694c",
-          "proxy": "0x676b7fbb358db45c434fb477c16dfd92fa436152",
-          "beacon": "0x8dc1c77718b6f97f4a1e06e234ba2c8defd9cf9a"
-        }
-      }
-    }
-  },
-  "bridge": {
-    "optimismkovan": {
-      "deployHeight": 3474763,
-      "bridgeRouter": {
-        "implementation": "0x1cad12645d171a46f64a2ac1695a5fd9c904ebfc",
-        "proxy": "0x9e76f5dfc22cfe83c06ef44fc318d5f923f33e2f",
-        "beacon": "0xc966ab655df40988f6ada362dbbfd4447dc47725"
-      },
-      "tokenRegistry": {
-        "implementation": "0x5c61715188d0eedb81dcbdd0fba16fe5add751d9",
-        "proxy": "0x952abfc4283f8d93f38a2993330b1b60ca3a8249",
-        "beacon": "0x359b05839b46efb969d97cd76a2aa4e172c75bba"
-      },
-      "bridgeToken": {
-        "implementation": "0x20fb023a95710adaa08ff87bd896cca4b15ec483",
-        "proxy": "0x0000000000000000000000000000000000000000",
-        "beacon": "0xbb9108c6fe2134be3445bbc6bfa57a223e66b612"
-      },
-      "ethHelper": "0x5ed597d469a81534749e14a177e59d68278d6dbb",
-      "customs": []
-    },
-    "arbitrumrinkeby": {
-      "deployHeight": 12099132,
-      "bridgeRouter": {
-        "implementation": "0x5aaa45f1329af4d2dd46e6e6cd70924b87f2d7dd",
-        "proxy": "0x2288254096c0b5747c6f48a93fd17a03f83dda24",
-        "beacon": "0x4272e577e40b3146d0269d1276542bba2adeaabf"
-      },
-      "tokenRegistry": {
-        "implementation": "0x9301dcce67e663dda07be9a5166a8b2bde12bac3",
-        "proxy": "0xcd817d1fed120aad28c64817a4a0277bd81aaa9d",
-        "beacon": "0x88b6740d1a8b3f25df6179fbcf83026867ee8523"
-      },
-      "bridgeToken": {
-        "implementation": "0xd926b924de53cf5adee4738f1608f7e25982499a",
-        "proxy": "0x0000000000000000000000000000000000000000",
-        "beacon": "0x3daa2126a75a205c25b540d791806b3445313ec0"
-      },
-      "ethHelper": "0x54b74b0e24bf83fbd5081a99a99566048d231bfa",
-      "customs": []
-    },
-    "rinkeby": {
-      "deployHeight": 10537318,
-      "bridgeRouter": {
-        "implementation": "0x4e103edd1971e2721105a1cb090d81821b70aa1e",
-        "proxy": "0x5731f3581d139e9a697448a34f55a89b781aac9a",
-        "beacon": "0xa778962b0ffbe7bc4449c308513a196bfa344232"
-      },
-      "tokenRegistry": {
-        "implementation": "0x2b91b5ce301bfc7b42927f40f9cef10b0c64f2f4",
-        "proxy": "0x7975a69a1fbccd03693e1ebec3e494be09d0604a",
-        "beacon": "0xa38175d60e5f3b08989694af084abdb9d86efba7"
-      },
-      "bridgeToken": {
-        "implementation": "0x4fc8561f45da09098b0fe0f983a16202bf03106a",
-        "proxy": "0x0000000000000000000000000000000000000000",
-        "beacon": "0xc19123a2afcc71220f603aec6228bc527db39fd0"
-      },
-      "ethHelper": "0x64586c361748e1973efdccda47c43bfd255d5238",
-      "customs": []
-    },
-    "kovan": {
-      "deployHeight": 31134545,
-      "bridgeRouter": {
-        "implementation": "0x2b56f51f74917852d19ec0b127358122a461dee3",
-        "proxy": "0xff3ecfa871d0419abf55ba5395c10c3c321c108c",
-        "beacon": "0xa3ff2c100c10fa34f3f79c79dd39aa86bc54326e"
-      },
-      "tokenRegistry": {
-        "implementation": "0x1d734e5897e8c98a25436bb85780e001310d5f34",
-        "proxy": "0xbedbb76cea6a3dc28ec3afbc137ec3b4749f4467",
-        "beacon": "0x4b6771cbd12526cba501b9e14cf98c391c4c8fdf"
-      },
-      "bridgeToken": {
-        "implementation": "0x9b5f25ae3edaf2ec85c484f425dce0dbe9ba7c98",
-        "proxy": "0x0000000000000000000000000000000000000000",
-        "beacon": "0x7af50c002a7e9e6fc683d8ca1d6840d3b5c285b7"
-      },
-      "ethHelper": "0xd71410e8f988ba97e95e2833ebf8d6c42cbcaa2d",
-      "customs": []
-    },
-    "evmostestnet": {
-      "deployHeight": 943064,
-      "bridgeRouter": {
-        "implementation": "0x52dbd0c2b9387ded247022806b645dc8a5aee8ff",
-        "proxy": "0x2d12e31c4ec3ee566b6f6eaab89875f4c18ef971",
-        "beacon": "0x3a58831408c67bf1ec7b4de773552c87a169b37e"
-      },
-      "tokenRegistry": {
-        "implementation": "0xbf394c127403ea4aaf56f42b8217fb4544c6e5be",
-        "proxy": "0x8887b5b8c798720690f8ca5a15bf26c3984f20e8",
-        "beacon": "0x3014dd7f749a62baea07b96fb929f14001a2e87f"
-      },
-      "bridgeToken": {
-        "implementation": "0xb0b95e5cc3e922a2b67fd3bbca1c18603a4d0ba4",
-        "proxy": "0x0000000000000000000000000000000000000000",
-        "beacon": "0x96f2380d5240e3634692694eab82f5609caee18d"
-      },
-      "ethHelper": "0x3bfcdad68bea1ed61fac49d050dabe0e1a482d30",
-      "customs": []
-    },
-    "goerli": {
-      "deployHeight": 6748625,
-      "bridgeRouter": {
-        "implementation": "0x9b68006a0740411a315ceeda30f160a5263af005",
-        "proxy": "0x17e9b5d4fbd4359875e19bd06359ded7fba33f4c",
-        "beacon": "0x1e0db0d3361c6e7e78b68079cad63daf5e337c49"
-      },
-      "tokenRegistry": {
-        "implementation": "0xe195d2e4c247b5cce1630cb0b39d8bfedf66c0f3",
-        "proxy": "0xcaca3358fd90c8e7ae9689ac4d21a8a7ec58c030",
-        "beacon": "0x20d53a6835d201fcf9cceab9309a044f75388b83"
-      },
-      "bridgeToken": {
-        "implementation": "0xa42a96cfd0ecdb41514908d8e0a0a55b14ec199d",
-        "proxy": "0x0000000000000000000000000000000000000000",
-        "beacon": "0xa0f7bd4594dacc63a91b3c7857dbc789309aabe8"
-      },
-      "ethHelper": "0x6f646837e542b47a7c982da5ceb3676caabc00bf",
-      "customs": []
-    },
-    "neontestnet": {
-      "deployHeight": 131969775,
-      "bridgeRouter": {
-        "implementation": "0xdd670cd32be311adf9d91b0fbe766c8da5da4bb4",
-        "proxy": "0xbac990165ec54c89b282791ee603b43801cc3218",
-        "beacon": "0x15668d7a4d73745a8354fdfea4657a9ccb77f831"
-      },
-      "tokenRegistry": {
-        "implementation": "0xfe5fc343e4b934c319675b8379753657d15b43ca",
-        "proxy": "0xc5109e06622689368755ee501a8282e3b9202617",
-        "beacon": "0xb8f51a5ca810b12f6a03652a64a9936f8acabe56"
-      },
-      "bridgeToken": {
-        "implementation": "0xac3f0fb1de6a8c2d93471ae3a1f8be6968b1fbcf",
-        "proxy": "0x0000000000000000000000000000000000000000",
-        "beacon": "0xbffbf61c61929216eed0a30d7b824ac2326a01c1"
-      },
-      "ethHelper": "0x298a4e631b2ac6620fffd264f698761ef8c15fb5",
-      "customs": []
-    }
-  },
-  "agent": {
-    "goerli": {
-      "rpcStyle": "ethereum",
-      "db": "/usr/share/nomad",
-      "metrics": 9090,
-      "logging": {
-        "fmt": "json",
-        "level": "info"
-      },
-      "updater": {
-        "interval": 5,
-        "enabled": true
-      },
-      "relayer": {
-        "interval": 10,
-        "enabled": true
-      },
-      "processor": {
-        "allowed": null,
-        "denied": null,
-        "subsidizedRemotes": [
-          "rinkeby",
-          "kovan",
-          "evmostestnet",
-          "neontestnet",
-          "arbitrumrinkeby",
-          "optimismkovan"
-        ],
-      },
-        },
-        "domain": 5001,
-        "name": "neontestnet",
-        "specs": {
-          "blockExplorer": "https://neonscan.org/",
-          "blockTime": 1,
-          "chainId": 245022934,
-          "confirmations": 10,
-          "finalizationBlocks": 32,
-          "indexPageSize": 2000,
-          "supports1559": false
-        }
-      "rinkeby": {
-        "bridgeConfiguration": {
-          "customs": [],
-          "deployGas": 850000,
-          "mintGas": 200000,
-          "weth": "0xc778417e063141139fce010982780140aa0cd5ab"
-        },
-        "configuration": {
-          "governance": {
-            "recoveryManager": "0xa4849f1d96b26066f9c631fcdc8f1457d27fb5ec",
-            "recoveryTimelock": 180
-          },
-          "maximumGas": 1000000,
-          "optimisticSeconds": 10,
-          "processGas": 850000,
-          "reserveGas": 15000,
-          "updater": "0xe80d5d65275208aee8e10609258e4e048eb86b4c",
-          "watchers": [
-            "0x8ad65ba028cae9e3932959d5c167a09ede941d2c"
-          ]
-        "interval": 500,
-        "enabled": true
-      }
-    },
-    "neontestnet": {
-      "rpcStyle": "ethereum",
-      "db": "/usr/share/nomad",
-      "metrics": 9090,
-      "logging": {
-        "fmt": "json",
-        "level": "info"
-      },
-      "updater": {
-        "interval": 5,
-        "enabled": true
-      },
-      "relayer": {
-        "interval": 10,
-        "enabled": true
-      },
-      "processor": {
-        "allowed": null,
-        "denied": null,
-        "subsidizedRemotes": [
-          "rinkeby",
-          "goerli",
-          "evmostestnet",
-          "kovan",
-          "arbitrumrinkeby",
-          "optimismkovan"
-        ],
-        "s3": {
-          "bucket": "nomadxyz-development-proofs",
-          "region": "us-west-2"
-        },
-        "interval": 5,
-        "enabled": true
-      },
-      "watcher": {
-        "interval": 5,
-        "enabled": true
-      },
-      "kathy": {
-        "chat": {
-          "type": "default"
-        },
-        "interval": 500,
-        "enabled": true
-      }
-    },
-    "kovan": {
-      "rpcStyle": "ethereum",
-      "db": "/usr/share/nomad",
-      "metrics": 9090,
-      "logging": {
-        "fmt": "json",
-        "level": "info"
-      },
-      "updater": {
-        "interval": 5,
-        "enabled": true
-      },
-      "relayer": {
-        "interval": 10,
-        "enabled": true
-      },
-      "processor": {
-        "allowed": null,
-        "denied": null,
-        "subsidizedRemotes": [
-          "rinkeby",
-          "goerli",
-          "evmostestnet",
-          "neontestnet",
-          "arbitrumrinkeby",
-          "optimismkovan"
-        ],
-        "s3": {
-          "bucket": "nomadxyz-development-proofs",
-          "region": "us-west-2"
-        },
-        "interval": 5,
-        "enabled": true
-      },
-      "watcher": {
-        "interval": 5,
-        "enabled": true
-      },
-      "kathy": {
-        "chat": {
-          "type": "default"
-        },
-        "interval": 500,
-        "enabled": true
-      }
-    },
-    "evmostestnet": {
-      "rpcStyle": "ethereum",
-      "db": "/usr/share/nomad",
-      "metrics": 9090,
-      "logging": {
-        "fmt": "json",
-        "level": "info"
-      },
-      "updater": {
-        "interval": 5,
-        "enabled": true
-      },
-      "relayer": {
-        "interval": 10,
-        "enabled": true
-      },
-      "processor": {
-        "allowed": null,
-        "denied": null,
-        "subsidizedRemotes": [
-          "rinkeby",
-          "kovan",
-          "goerli",
-          "neontestnet",
-          "arbitrumrinkeby",
-          "optimismkovan"
-        ],
-        "s3": {
-          "bucket": "nomadxyz-development-proofs",
-          "region": "us-west-2"
-        },
-        "interval": 5,
-        "enabled": true
-      },
-      "watcher": {
-        "interval": 5,
-        "enabled": true
-      },
-      "kathy": {
-        "chat": {
-          "type": "default"
-        },
-        "interval": 500,
-        "enabled": true
-      }
-    },
-    "rinkeby": {
-      "rpcStyle": "ethereum",
-      "db": "/usr/share/nomad",
-      "metrics": 9090,
-      "logging": {
-        "fmt": "json",
-        "level": "info"
-      },
-      "updater": {
-        "interval": 5,
-        "enabled": true
-      },
-      "relayer": {
-        "interval": 10,
-        "enabled": true
-      },
-      "processor": {
-        "allowed": null,
-        "denied": null,
-        "subsidizedRemotes": [
-          "kovan",
-          "goerli",
-          "evmostestnet",
-          "neontestnet",
-          "arbitrumrinkeby",
-          "optimismkovan"
-        ],
-        "s3": {
-          "bucket": "nomadxyz-development-proofs",
-          "region": "us-west-2"
-        },
-        "interval": 5,
-        "enabled": true
-      },
-      "watcher": {
-        "interval": 5,
-        "enabled": true
-      },
-      "kathy": {
-        "chat": {
-          "type": "default"
-        },
-        "interval": 500,
-        "enabled": true
-      }
-    },
-    "arbitrumrinkeby": {
-      "rpcStyle": "ethereum",
-      "db": "/usr/share/nomad",
-      "metrics": 9090,
-      "logging": {
-        "fmt": "json",
-        "level": "info"
-      },
-      "updater": {
-        "interval": 5,
-        "enabled": true
-      },
-      "relayer": {
-        "interval": 10,
-        "enabled": true
-      },
-      "processor": {
-        "allowed": null,
-        "denied": null,
-        "subsidizedRemotes": [
-          "kovan",
-          "goerli",
-          "evmostestnet",
-          "neontestnet",
-          "rinkeby",
-          "optimismkovan"
-        ],
-        "s3": {
-          "bucket": "nomadxyz-development-proofs",
-          "region": "us-west-2"
-        },
-        "interval": 5,
-        "enabled": true
-      },
-      "watcher": {
-        "interval": 5,
-        "enabled": true
-      },
-      "kathy": {
-        "chat": {
-          "type": "default"
-        },
-        "interval": 500,
-        "enabled": true
-      }
-    },
-    "optimismkovan": {
-      "rpcStyle": "ethereum",
-      "db": "/usr/share/nomad",
-      "metrics": 9090,
-      "logging": {
-        "fmt": "json",
-        "level": "info"
-      },
-      "updater": {
-        "interval": 5,
-        "enabled": true
-      },
-      "relayer": {
-        "interval": 10,
-        "enabled": true
-      },
-      "processor": {
-        "allowed": null,
-        "denied": null,
-        "subsidizedRemotes": [
-          "kovan",
-          "goerli",
-          "evmostestnet",
-          "neontestnet",
-          "arbitrumrinkeby",
-          "rinkeby"
-        ],
-        "s3": {
-          "bucket": "nomadxyz-development-proofs",
-          "region": "us-west-2"
-        },
-        "interval": 5,
-        "enabled": true
-      },
-      "watcher": {
-        "interval": 5,
-        "enabled": true
-      },
-      "kathy": {
-        "chat": {
-          "type": "default"
-        },
-        "interval": 500,
-        "enabled": true
-      }
-    }
-  },
-  "gas": {
-    "rinkeby": "evmDefault",
-    "kovan": "evmDefault",
-    "goerli": "evmDefault",
-    "evmostestnet": "evmDefault"
-  },
-  "bridgeGui": {
-    "goerli": {
-      "displayName": "Goerli",
-      "nativeTokenSymbol": "gETH",
-      "connections": ["rinkeby"],
-      "connextEnabled": true
-    },
-    "rinkeby": {
-      "displayName": "Rinkeby",
-      "nativeTokenSymbol": "rETH",
-      "connections": ["kovan", "goerli", "evmostestnet", "neontestnet"],
-      "manualProcessing": true,
-      "connextEnabled": true
-    },
-    "evmostestnet": {
-      "displayName": "Evmos Testnet",
-      "nativeTokenSymbol": "tEVMOS",
-      "connections": ["rinkeby"]
-    },
-    "kovan": {
-      "displayName": "Kovan",
-      "nativeTokenSymbol": "kETH",
-      "connections": ["rinkeby"],
-      "connextEnabled": true
-    },
-    "neontestnet": {
-      "displayName": "Neon Testnet",
-      "nativeTokenSymbol": "tNEON",
-      "connections": ["rinkeby"]
-    }
-  }
 }


### PR DESCRIPTION
- Adds arbitrum-rinkeby and optimism-kovan deployments to dev
- Also lowers rinkeby/goerli finalization to 30 blocks to avoid massive delays