### PR TITLE
update: prod bridgeGui connections

### DIFF
--- a/production.json
+++ b/production.json
@@ -437,7 +437,9 @@
     },
     "evmos": {
       "connections": [
-        "ethereum"
+        "ethereum",
+        "moonbeam",
+        "milkomedaC1"
       ],
       "connextEnabled": true,
       "displayName": "Evmos",
@@ -445,14 +447,18 @@
     },
     "milkomedaC1": {
       "connections": [
-        "ethereum"
+        "ethereum",
+        "moonbeam",
+        "evmos"
       ],
       "displayName": "Milkomeda C1",
       "nativeTokenSymbol": "milkADA"
     },
     "moonbeam": {
       "connections": [
-        "ethereum"
+        "ethereum",
+        "milkomedaC1",
+        "moonbeam"
       ],
       "connextEnabled": true,
       "displayName": "Moonbeam",

--- a/production.json
+++ b/production.json
@@ -438,8 +438,8 @@
     "evmos": {
       "connections": [
         "ethereum",
-        "moonbeam",
-        "milkomedaC1"
+        "milkomedaC1",
+        "moonbeam"
       ],
       "connextEnabled": true,
       "displayName": "Evmos",
@@ -448,8 +448,8 @@
     "milkomedaC1": {
       "connections": [
         "ethereum",
-        "moonbeam",
-        "evmos"
+        "evmos",
+        "moonbeam"
       ],
       "displayName": "Milkomeda C1",
       "nativeTokenSymbol": "milkADA"


### PR DESCRIPTION
Enable evmos <> milkomeda <> moonbeam connections (networks where liquidity fragmentation is not a concern)